### PR TITLE
Fix isPrivateLink missing return

### DIFF
--- a/lib/links.js
+++ b/lib/links.js
@@ -4,7 +4,7 @@ const privateLinks = require ('../config/markdown/privateLinksList');
 // @param privateDomains [Array<String>] A list of private / protected domain names
 const isPrivateLink = (token, privateDomains=privateLinks) => { /* eslint-disable-line no-unused-vars */
   const href = token.attrGet('href')
-  privateDomains.some(privateDomain => href.includes(privateDomain))
+  return privateDomains.some(privateDomain => href.includes(privateDomain))
 }
 
 /* Determine if a given link is external (to the Federal government)


### PR DESCRIPTION
## Summary
- fix `isPrivateLink` so it returns the boolean result

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e3eb6c02c832e8d8f9ce65638917a