### PR TITLE
Fix NASA HTTPS blog excerpt

### DIFF
--- a/content/posts/2017-05-25-from-launch-to-landing-how-nasa-took-control-of-its-https-mission.md
+++ b/content/posts/2017-05-25-from-launch-to-landing-how-nasa-took-control-of-its-https-mission.md
@@ -7,7 +7,7 @@ tags:
 - security
 - convincing stakeholders
 - lessons learned
-excerpt: "In 2015, the White House Office of Management and Budget released M-15-13, a \"Policy to Require Secure Connections across Federal Websites and Web Services\" the memo emphasizes the importance of protecting the privacy and security of the public's browsing activities on teh web. This is a guest post by Karim Said of NASA who was instrumental in NASA's successful HTTPS and HSTS migration."
+excerpt: "In 2015, the White House Office of Management and Budget released M-15-13, a \"Policy to Require Secure Connections across Federal Websites and Web Services\" the memo emphasizes the importance of protecting the privacy and security of the public's browsing activities on the web. This is a guest post by Karim Said of NASA who was instrumental in NASA's successful HTTPS and HSTS migration."
 image: /assets/blog/nasa-https/pshtt-code.png
 ---
 


### PR DESCRIPTION
## Summary
- fix a typo in the NASA HTTPS blog post excerpt

## Testing
- `npm run precommit` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e457cfba0832e90e78d344e7970a5