### PR TITLE
Add isPrivateLink tests

### DIFF
--- a/test/lib/is_private_link_test.js
+++ b/test/lib/is_private_link_test.js
@@ -1,0 +1,20 @@
+const chai = require('chai')
+const Token = require('markdown-it/lib/token')
+
+const { expect } = chai
+
+const { isPrivateLink } = require('../../lib/links')
+
+describe('.isPrivateLink', () => {
+  context('with a private domain', () => {
+    const token = new Token()
+    token.attrPush(['href', 'https://18f.slack.com/team'])
+    it('returns true', async () => expect(isPrivateLink(token)).to.be.true)
+  })
+
+  context('with a public domain', () => {
+    const token = new Token()
+    token.attrPush(['href', 'https://example.com'])
+    it('returns false', async () => expect(isPrivateLink(token)).to.be.false)
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for `isPrivateLink`

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e45799984832e9bd6f9fee8aecbc9